### PR TITLE
PF_TITLECOLOR option to use one color for all the text

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ PF_COL2=9
 
 # Color of title data:
 # Default: unset (auto)
-# Valid: 0-9
+# Valid: 0-9, COL1 (copies COL1 value)
 PF_COL3=1
 
 # Alignment paddings (this is different to the original version).

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,10 +260,10 @@ fn main() {
         }
     }
 
-    if dotenvy::var("PF_TITLECOLOR").unwrap_or_default() == "0" {
-        logo.secondary_color = logo.primary_color;
-    } else if let Ok(newcolor) = dotenvy::var("PF_COL3") {
-        if let Ok(newcolor) = pfetch::Color::from_str(&newcolor) {
+    if let Ok(newcolor) = dotenvy::var("PF_COL3") {
+        if newcolor == "COL1" {
+            logo.secondary_color = logo.primary_color;
+        } else if let Ok(newcolor) = pfetch::Color::from_str(&newcolor) {
             logo.secondary_color = newcolor;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,7 +260,9 @@ fn main() {
         }
     }
 
-    if let Ok(newcolor) = dotenvy::var("PF_COL3") {
+    if dotenvy::var("PF_TITLECOLOR").unwrap_or_default() == "0" {
+        logo.secondary_color = logo.primary_color;
+    } else if let Ok(newcolor) = dotenvy::var("PF_COL3") {
         if let Ok(newcolor) = pfetch::Color::from_str(&newcolor) {
             logo.secondary_color = newcolor;
         }


### PR DESCRIPTION
![Screenshot from 2023-03-15 12-09-42](https://user-images.githubusercontent.com/57970114/225371071-4c1b8654-464e-4fea-96a1-b0b86b4ec1a9.png)

I haven't written any rust before this, I just used what github copilot gave me when I made a comment saying what I wanted, so sorry if the code sucks