### PR TITLE
perfectly accurate command line behavior

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -194,15 +194,28 @@ fn get_info(
     }
 }
 
+fn usage() {
+    println!("pfetch     show system information");
+    println!("pfetch -v  show version");
+    std::process::exit(0);
+}
+
 fn main() {
-    // parse arguements
-    if std::env::args().any(|arg| arg.starts_with("-v") || arg.starts_with("--v")) {
-        println!("pfetch-rs {}", env!("CARGO_PKG_VERSION"));
-        std::process::exit(0);
-    } else if std::env::args().len() > 1 {
-        println!("pfetch     show system information");
-        println!("pfetch -v  show version");
-        std::process::exit(0);
+    // parse command line arguments
+    match std::env::args().len() {
+        2 => match std::env::args().nth(1).unwrap().as_str() {
+            "-v" | "--version" => {
+                println!("pfetch-rs {}", env!("CARGO_PKG_VERSION"));
+                std::process::exit(0);
+            }
+            "-d" | "--debug" => {
+                // in pfetch this enables stderr, but that doesn't make sense here so we just
+                // ignore it
+            }
+            _ => usage(),
+        },
+        1 | 0 => {}
+        _ => usage(),
     }
 
     // source file specified by env: PF_SOURCE


### PR DESCRIPTION
rework command line argument parsing to behave exactly the same as in the sh version

passing more than one argument always prints a usage message, and the debug flag is ignored instead of printing a usage message (assuming there are no bugs, sh pfetch shouldn't print anything to stderr anyway, so it behaves the same)